### PR TITLE
add scarthgap to compatible list

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -15,4 +15,4 @@ BBFILE_PATTERN_meta-scipy = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-scipy = "6"
 
 LAYERDEPENDS_meta-scipy = "core openembedded-layer meta-python"
-LAYERSERIES_COMPAT_meta-scipy = "gatesgarth hardknott honister kirkstone langdale mickledore nanbield"
+LAYERSERIES_COMPAT_meta-scipy = "gatesgarth hardknott honister kirkstone langdale mickledore nanbield scarthgap"


### PR DESCRIPTION
This just adds scrathgap to the list of compatible yocto versions so we can built it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/meta-scipy/1)
<!-- Reviewable:end -->
